### PR TITLE
Bumped version to 1.5.0 for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 Rivet CHANGELOG
 ===
 
+1.5.0 - Released 12/12/13
+---
+  * BREAKING CHANGE: The gem list in bootstrap['gems'] must be converted from a list of
+    Arrays to a Hash in yaml definition files, please look at README.md
+  * Added functionality to apply specific named configs in a group (merges into and takes
+    precedence over the group config) for nodes within a group that have unique attributes
+  * Improved Rivet's CLI option parser. It now uses OpenStruct instead of a Hash for the options,
+    has cleaner user error messages with cmd help displayed and supports exit status codes
+
 1.4.0 - Released 11/22/13
 ---
   * Adds functionality to apply an elastic_ip durning bootstrap

--- a/Gemfile
+++ b/Gemfile
@@ -7,4 +7,4 @@ group(:development, :test) do
   gem 'rspec', '~> 2.14.1'
 end
 
-gem 'aws-sdk',  '>= 1.11.1'
+gem 'aws-sdk',  '>= 1.30.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,17 +1,20 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    aws-sdk (1.24.0)
+    aws-sdk (1.30.0)
       json (~> 1.4)
-      nokogiri (>= 1.4.4, < 1.6.0)
+      nokogiri (>= 1.4.4)
       uuidtools (~> 2.1)
     diff-lcs (1.2.5)
     ffi2-generators (0.1.1)
     json (1.8.1)
     json (1.8.1-java)
+    mini_portile (0.5.2)
     minitest (4.7.5)
-    nokogiri (1.5.10)
-    nokogiri (1.5.10-java)
+    nokogiri (1.6.0)
+      mini_portile (~> 0.5.0)
+    nokogiri (1.6.0-java)
+      mini_portile (~> 0.5.0)
     rake (10.1.0)
     rspec (2.14.1)
       rspec-core (~> 2.14.0)
@@ -240,7 +243,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  aws-sdk (>= 1.11.1)
+  aws-sdk (>= 1.30.0)
   rake (>= 10.1.0)
   rspec (~> 2.14.1)
   rubysl

--- a/bin/rivet
+++ b/bin/rivet
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
 
 $:.unshift(File.join(File.dirname(__FILE__), "..", "lib"))
+require 'ostruct'
 require 'rivet'
 require 'rivet/client'
 
@@ -10,39 +11,55 @@ FATAL = Logger::FATAL
 INFO  = Logger::INFO
 
 # Default option values
-options = {
-  :log_level => INFO,
-  :profile => 'default',
-  :definitions_directory => './autoscale'
-}
+options                        = OpenStruct.new
+options.log_level              = INFO
+options.profile                = 'default'
+options.definitions_directory  = './autoscale'
+options.config                 = nil
 
 OptionParser.new do |o|
-  o.on('-g', '--group [GROUP_NAME]', String, 'Autoscaling group name') do |g|
-    options[:group] = g
+  o.on('-g', '--group GROUP_NAME', String, 'Autoscaling group name') do |g|
+    options.group = g
   end
 
-  o.on('-l', '--log-level [LEVEL]', String, "specify the log level (default is INFO)") do |l|
-    options[:log_level] = Kernel.const_get l.upcase
+  o.on('-c', '--config [CONFIG_NAME]', String, 'Specify config name (exclude \'.yml\') within an autoscaling group (optional) ') do |c|
+    options.config = "#{c}.yml"
   end
 
+  o.on('-l', '--log-level [LEVEL]', String, "Specify the log level (default is INFO)") do |l|
+    options.log_level = Kernel.const_get l.upcase
+  end
 
   o.on('-p', '--profile [PROFILE_NAME]', "Selects the AWS profile to use (default is 'default')") do |p|
-    options[:profile] = p
+    options.profile = p
   end
 
   o.on('-s', '--sync', "Sync the changes remotely to AWS") do |s|
-    options[:sync] = s
+    options.sync = s
   end
 
   o.on('-d', '--definitions-directory [PATH]', "The autoscale definitions directory to use (default is ./autoscale)") do |d|
-    options[:definitions_directory] = d
+    options.definitions_directory = d
   end
 
   o.on('-h') { puts o; exit }
-  o.parse!
+
+  begin
+    o.parse!
+    required = %w(group)
+    missing = required.select{ |param| options.send(param).nil? }
+    unless missing.empty?
+      puts "Missing required options: #{missing.join(', ')}"
+      puts o
+      exit 255
+    end
+  rescue OptionParser::InvalidOption, OptionParser::MissingArgument
+    puts $!.to_s
+    puts o
+    exit 255
+  end
+
+  puts "Rivet running with options: #{options.inspect}"
 end
 
-raise "--group [GROUP_NAME] argument is required!" if options[:group].nil?
-
-Rivet::Client.new.run(options)
-
+exit Rivet::Client.new.run(options)

--- a/lib/rivet/bootstrap.rb
+++ b/lib/rivet/bootstrap.rb
@@ -55,11 +55,11 @@ module Rivet
 
       install_gems = ''
 
-      gems.each do |g|
-        if g.size > 1
-          install_gems << "gem install #{g[0]} -v #{g[1]} --no-rdoc --no-ri\n"
+      gems.each do |k, v|
+        if v
+          install_gems << "gem install #{k} -v #{v} --no-rdoc --no-ri\n"
         else
-          install_gems << "gem install #{g[0]} --no-rdoc --no-ri\n"
+          install_gems << "gem install #{k} --no-rdoc --no-ri\n"
         end
       end unless gems.nil?
 

--- a/lib/rivet/client.rb
+++ b/lib/rivet/client.rb
@@ -4,31 +4,33 @@ module Rivet
     end
 
     def run(options)
-      AwsUtils.set_aws_credentials(options[:profile])
-      Rivet::Log.level(options[:log_level])
+      AwsUtils.set_aws_credentials(options.profile)
+      Rivet::Log.level(options.log_level)
 
-      unless Dir.exists?(options[:definitions_directory])
+      unless Dir.exists?(options.definitions_directory)
         Rivet::Utils.die("The autoscale definitions directory doesn't exist")
       end
 
-      group_def = Rivet::Utils.get_definition(
-        options[:group],
-        options[:definitions_directory])
+      definition = Rivet::Utils.get_definition(
+        options.config,
+        options.group,
+        options.definitions_directory)
 
-      unless group_def
-        Rivet::Utils.die "The #{options[:group]} definition doesn't exist"
+      unless definition
+        Rivet::Utils.die "The #{options.group} definition doesn't exist"
       end
 
-      Rivet::Log.info("Checking #{options[:group]} autoscaling definition")
-      autoscale_def = Rivet::Autoscale.new(options[:group], group_def)
+      Rivet::Log.info("Checking #{options.group} autoscaling definition")
+      autoscale_def = Rivet::Autoscale.new(options.group, definition)
       autoscale_def.show_differences
 
-      if options[:sync]
+      if options.sync
         autoscale_def.sync
       else
         Rivet::Log.info("use the -s [--sync] flag to sync changes")
       end
 
+      exitstatus = 0
     end
 
   end

--- a/lib/rivet/version.rb
+++ b/lib/rivet/version.rb
@@ -1,3 +1,3 @@
 module Rivet
-  VERSION = '1.4.0'
+  VERSION = '1.5.0'
 end


### PR DESCRIPTION
- BREAKING CHANGE: The gem list in bootstrap['gems'] must be converted
  from a list of Arrays to a Hash in yaml definition files, please
  look at README.md
- Added functionality to apply specific named configs in a group
  (merges into and takes precedence over the group config) for nodes
  within a group that have unique attributes
- Improved Rivet's CLI option parser. It now uses OpenStruct instead
  of a Hash for the options, has cleaner user error messages with cmd
  help displayed and supports exit status codes
- Updated and added some unit tests
- Bumpted aws-sdk to 1.30.0 in the Gemfile
- Updated README.md and CHANGELOG.md
